### PR TITLE
Fix cdnjs branding

### DIFF
--- a/content/stuff/cdnjs.md
+++ b/content/stuff/cdnjs.md
@@ -1,6 +1,6 @@
 +++
 date = 2021-06-21T06:55:21.618Z
-title = "CDN js"
+title = "cdnjs"
 link = "https://cdnjs.com/"
 thumbnail = "https://res.cloudinary.com/wegoatdev/image/upload/v1624258688/freestuffdev/stuff/Screen_Shot_2021-06-21_at_2.57.40_PM.png"
 snippet="Simple. Fast. Reliable. Content delivery at its finest. cdnjs is a free and open-source CDN service trusted by over 11% of all websites, powered by Cloudflare. We make it faster and easier to load library files on your websites."


### PR DESCRIPTION
Just a quick fix for the cdnjs branding: "CDN js" -> "cdnjs"