### PR TITLE
fix: thumbnail picture dimensions

### DIFF
--- a/content/stuff/pagely.md
+++ b/content/stuff/pagely.md
@@ -2,7 +2,7 @@
 date = 2021-08-02T07:18:16.065Z
 title = "Pagely"
 link = "http://www.pagely.site/"
-thumbnail = "https://www.pagely.site/_next/image?url=%2F_next%2Fstatic%2Fimage%2Fpublic%2Flogo.c78d25215da13228ac496e6919c36551.png&w=828&q=75"
+thumbnail = "https://www.pagely.site/logo-small.png"
 snippet="Launch SEO friendly, blazing fast websites from Notion, Google Sheets, GitHub, Airtable with Pagely"
 tags = ["nocode","hosting-static","hosting"]
 +++


### PR DESCRIPTION
Fix the logo dimensions. The current logo looks compressed
![image](https://user-images.githubusercontent.com/69138026/127829541-9e72c0bf-d848-49eb-88ef-cb9d8751e118.png)
