### PR TITLE
Fix some broken link image thumbnails

### DIFF
--- a/content/stuff/bitwarden.md
+++ b/content/stuff/bitwarden.md
@@ -2,7 +2,7 @@
 date = 2021-06-28T22:17:26.586Z
 title = "Bitwarden"
 link = "https://bitwarden.com/"
-thumbnail = "https://bitwarden.com/images/icons/apple-touch-icon.png"
+thumbnail = "https://pbs.twimg.com/profile_images/1251939728678481920/Wkb7Syl9_400x400.jpg"
 snippet="Bitwarden, the open source password manager, makes it easy to generate and store unique passwords for any browser or device. Create your free account on the platform with end-to-end encryption and flexible integration options for you or your business."
 tags = ["password-manager"]
 +++

--- a/content/stuff/bookmark-os.md
+++ b/content/stuff/bookmark-os.md
@@ -3,7 +3,7 @@ date = 2021-06-20T05:04:30.697Z
 tags = ["productivity", "storage", "note-taking", "task-manager"]
 title="Bookmark OS"
 link = "https://bookmarkos.com/"
-thumbnail = "https://i.imgur.com/kgwkIaU.png"
+thumbnail = "https://pbs.twimg.com/profile_images/697846715001364480/NPRgkHqm_400x400.png"
 snippet="Easily organize your digital life"
 +++
 Free offer: Free bookmark manager, task manager, notes, and 500MB of files.

--- a/content/stuff/canva.md
+++ b/content/stuff/canva.md
@@ -3,7 +3,7 @@ date = "2021-08-14T00:00:00+00:00"
 tags = ["design"]
 title="Canva"
 link = "https://www.canva.com/"
-thumbnail = "https://pbs.twimg.com/profile_images/1425980048322953217/WKM50IAL_400x400.png"
+thumbnail = "https://pbs.twimg.com/profile_images/1445210966791057408/uNepfpGS_400x400.jpg"
 snippet="With Canva, anyone can create professional looking graphics and designs. Featuring thousands of templates and an easy to use editor."
 +++
 250,000+ free templates

--- a/content/stuff/hoppscotch.md
+++ b/content/stuff/hoppscotch.md
@@ -2,7 +2,7 @@
 date = 2021-06-21T07:14:15.769Z
 title = "Hoppscotch"
 link = "https://hoppscotch.io/"
-thumbnail = "https://hoppscotch.io/_nuxt/icons/icon_64x64.9834b3.png"
+thumbnail = "https://pbs.twimg.com/profile_images/1438778186469306371/IbJoDwEO_400x400.jpg"
 snippet="Helps you create requests faster, saving precious time on development."
 tags = ["API","API-testing"]
 +++

--- a/content/stuff/sourcegraph.md
+++ b/content/stuff/sourcegraph.md
@@ -3,7 +3,7 @@ date = "2021-06-21T16:25:00+08:00"
 tags = ["code-search","code-intelligence"]
 title="Sourcegraph"
 link = "https://sourcegraph.com"
-thumbnail = "https://sourcegraph.com/.assets/img/sourcegraph-head-logo.svg?v2"
+thumbnail = "https://sourcegraph.com/.assets/img/sourcegraph-mark.svg?v2"
 snippet="Sourcegraph universal code search enables developers to explore and better understand all code, faster, with contextual code intelligence to improve developer productivity and automate large-scale code change management."
 +++
 Open source

--- a/content/stuff/spline-3d.md
+++ b/content/stuff/spline-3d.md
@@ -2,7 +2,7 @@
 date = 2021-08-21T04:20:00
 title = "Spline"
 link = "https://spline.design/"
-thumbnail = "https://pbs.twimg.com/profile_images/1372311969051594755/gjfXnj8f_400x400.jpg"
+thumbnail = "https://d33wubrfki0l68.cloudfront.net/6e818a6053f5a11d48f2070de259173df357290c/207d7/_assets/_images/spline_logo.png"
 snippet="Create web-based 3D experiences"
 tags = ["design"," 3D"," asset"]
 +++

--- a/content/stuff/swagger.md
+++ b/content/stuff/swagger.md
@@ -3,7 +3,7 @@ date = "2021-08-26T00:00:00+00:00"
 tags = ["API","API-documentation"]
 title="Swagger"
 link = "https://swagger.io/"
-thumbnail = "https://pbs.twimg.com/profile_images/1074670433260187648/de6FXq-d_400x400.jpg"
+thumbnail = "https://pbs.twimg.com/profile_images/1451297216187011072/xLd1JSZk_400x400.png"
 snippet="Simplify API development for users, teams, and enterprises with the Swagger open source and professional toolset. Find out how Swagger can help you design and document your APIs at scale."
 +++
 1 User

--- a/content/stuff/upwork.md
+++ b/content/stuff/upwork.md
@@ -2,7 +2,7 @@
 date = 2021-06-23T16:30:14+00:00
 title = "UpWork"
 link = "https://www.upwork.com/"
-thumbnail = "https://careers.upwork.com/hs-fs/hubfs/raw_assets/public/Upwork_Spring_2021_Rebrand/images/logo.png"
+thumbnail = "https://pbs.twimg.com/profile_images/1389671445953921029/8D3jABqV_400x400.jpg"
 snippet="The World's Work Marketplace for Freelancing"
 tags = ["job-listing"]
 +++


### PR DESCRIPTION
Fix some broken link image thumbnails on Swagger, Spline, Canva, Bitwarden, UpWork, Sourcegraph, Hoppscotch and Bookmark OS
![1](https://user-images.githubusercontent.com/69706046/138565335-6401e1d8-cb74-41f9-9dae-abca91088df5.png) ![2](https://user-images.githubusercontent.com/69706046/138565338-a8750562-8b9d-40aa-b1ff-a2550ebb954a.png) ![3](https://user-images.githubusercontent.com/69706046/138565339-2f6d8d15-c342-4668-be5e-d80a5d858667.png) ![4](https://user-images.githubusercontent.com/69706046/138565343-7795cb06-0f03-4a11-a24a-003c2c4a646d.png)
![5](https://user-images.githubusercontent.com/69706046/138565347-649167df-7b2c-43b7-8269-d5206269d367.png) ![6](https://user-images.githubusercontent.com/69706046/138565348-062e3e7b-b890-4ae2-9235-255cd819edcd.png) ![7](https://user-images.githubusercontent.com/69706046/138565349-eab5f533-bf1a-4d94-863f-8f16e1e557a3.png) ![8](https://user-images.githubusercontent.com/69706046/138565351-8a388720-094f-43b7-9619-f4fb503235a1.png)