### PR TITLE
Update Heroku Entry to give more info about the removal of free tier

### DIFF
--- a/content/stuff/heroku.md
+++ b/content/stuff/heroku.md
@@ -6,8 +6,4 @@ thumbnail = "https://ik.imagekit.io/kodingclub/freestuffdev/stuff/heroku_yiaO6EI
 snippet="Heroku is a container-based cloud Platform as a Service (PaaS). Developers use Heroku to deploy, manage, and scale modern apps. Our platform is elegant, flexible, and easy to use, offering developers the simplest path to getting their apps to market."
 tags = ["database","hosting-dynamic","paas"]
 +++
-550-1,000 dyno hours per month
-Deploy with Git and Docker
-Custom domains
-Container orchestration
-Automatic OS patching
+No longer valid as starting Nov. 28, 2022, the company will stop offering free product plans.


### PR DESCRIPTION
As we know heroku has stopped offering free tier on their products and current free tier projects will be auto stopped starting Starting November 28. See this info [here](https://techcrunch.com/2022/08/25/heroku-announces-plans-to-eliminate-free-plans-blaming-fraud-and-abuse)

This PR resolves Issue #248 