### PR TITLE
Changed the textpad->thunderpad in the description

### DIFF
--- a/content/stuff/thunderpad.md
+++ b/content/stuff/thunderpad.md
@@ -3,6 +3,6 @@ date = 2023-01-10T16:55:51.673Z
 title = "Thunderpad"
 link = "http://thunderpad.weebly.com/"
 thumbnail = ""
-snippet="Textpad is a simple, general-purpose and cross-platform text editor written in C++ using the Qt libraries. Textpad aims to be faster and more lightweight than most text editors, but as useful as them."
+snippet="Thunderpad is a simple, general-purpose and cross-platform text editor written in C++ using the Qt libraries. Thunderpad aims to be faster and more lightweight than most text editors, but as useful as them."
 tags = ["text-editor"]
 +++


### PR DESCRIPTION
Noticed some error as the description stated as if the name of  the project was Textpad. However, I checked their website and the actual name is Thunderpad, hence I've corrected it.