### PR TITLE
Add FastCron

### DIFF
--- a/content/stuff/fastcron.md
+++ b/content/stuff/fastcron.md
@@ -1,6 +1,6 @@
 +++
-date = 2023-02-08T14:01:13.249Z
-title = "FastCron - online cron job service"
+date = 2023-02-14T14:01:13.249Z
+title = "FastCron"
 link = "https://www.fastcron.com/"
 thumbnail = "https://www.fastcron.com/favicon.ico"
 snippet="Set cron jobs easily, know when your cron jobs are executed, get email notifications, Slack messages, or webhooks."

--- a/content/stuff/fastcron.md
+++ b/content/stuff/fastcron.md
@@ -1,0 +1,12 @@
++++
+date = 2023-02-08T14:01:13.249Z
+title = "FastCron - online cron job service"
+link = "https://www.fastcron.com/"
+thumbnail = "https://www.fastcron.com/favicon.ico"
+snippet="Set cron jobs easily, know when your cron jobs are executed, get email notifications, Slack messages, or webhooks."
+tags = ["cron"]
++++
+300 cronjob executions a day
+3 recurring cronjobs / 300 one-time cronjobs
+Cron timeout 60 seconds
+View last 10 execution results


### PR DESCRIPTION
I'd like to add FastCron, an online cronjob service. You can create a cronjob to run your backend tasks via an URL (e.g. http://example.com/backup.php).