### PR TITLE
Fix issue #823: broken link fix

### DIFF
--- a/content/stuff/trinket.md
+++ b/content/stuff/trinket.md
@@ -1,7 +1,7 @@
 +++
 date = 2021-10-14T18:39:00.565Z
 title = "Trinket"
-link = "https://trinket.io/"
+link = "https://trinket.io"
 thumbnail = "https://trinket.io/cache-prefix-94212f79/img/icons/apple-touch-icon-144x144-precomposed.png"
 snippet="Share Code from any Device. Trinket lets you run and write code in any browser, on any device."
 tags = ["course-builder","teaching","playground"," web-development"]


### PR DESCRIPTION
Fix for https://github.com/hilmanski/freeStuffDev/issues/823
Currently its redirecting to https://trinket.io/?ref=freeStuffDev
expected redirection is https://trinket.io?ref=freeStuffDev