### PR TITLE
Fixing thumbnail url for some services

### DIFF
--- a/content/stuff/Atom.md
+++ b/content/stuff/Atom.md
@@ -2,7 +2,7 @@
 date = 2021-06-21T03:23:14.121Z
 title = "Atom"
 link = "https://atom.io/"
-thumbnail = "https://atom.io/favicon.ico"
+thumbnail = "https://github.githubassets.com/favicon.ico"
 snippet="At GitHub, we’re building the text editor we’ve always wanted: hackable to the core, but approachable on the first day without ever touching a config file. We can’t wait to see what you build with it."
 tags = ["text-editor"]
 +++

--- a/content/stuff/bitbucket-pipeline.md
+++ b/content/stuff/bitbucket-pipeline.md
@@ -2,7 +2,7 @@
 date = 2021-06-17T17:18:35+08:00
 title = "Bitbucket Pipeline"
 link = "https://bitbucket.org/product/features/pipelines"
-thumbnail = "https://wac-cdn.atlassian.com/assets/img/favicons/bitbucket/apple-touch-icon.png"
+thumbnail = "https://wac-cdn.atlassian.com/assets/img/favicons/bitbucket/favicon-32x32.png"
 snippet="Bitbucket Pipelines brings continuous integration and delivery to Bitbucket Cloud, empowering teams to build, test, and deploy their code within Bitbucket"
 tags = ["CI-CD"]
 +++

--- a/content/stuff/bytebase.md
+++ b/content/stuff/bytebase.md
@@ -2,7 +2,7 @@
 date = 2022-10-11T05:43:00
 title = "Bytebase"
 link = "https://www.bytebase.com/"
-thumbnail = "https://www.bytebase.com/favicon.ico"
+thumbnail = "https://www.bytebase.com/favicon/favicon.png"
 snippet="Safer and faster database change and version control for DBAs and Developers"
 tags = ["database"," devops"]
 +++

--- a/content/stuff/drovio.md
+++ b/content/stuff/drovio.md
@@ -2,7 +2,7 @@
 date = 2021-07-02T05:41:30.225Z
 title = "Drovio"
 link = "https://www.drovio.com/"
-thumbnail = "https://www.drovio.com/assets/images/logo-header-2.svg"
+thumbnail = "https://www.drovio.com/assets/images/logo.svg"
 snippet="Bring your remote team together with Drovio. Collaborate on your screen, every participant gets their own mouse cursor and you're all in control."
 tags = ["pair-programming"]
 +++

--- a/content/stuff/lemon.md
+++ b/content/stuff/lemon.md
@@ -2,7 +2,7 @@
 date = 2021-09-25T05:14:00
 title = "Lemon"
 link = "https://uselemon.io/"
-thumbnail = "https://uselemon.io/assets/favicon/favicon.ico"
+thumbnail = "https://uselemon.io/images/favicon.ico"
 snippet="AWS is like an airplane cockpit – you have to be an expert to use it. Lemon is more like your phone – intuitive, no manual needed. Fully customisable with Terraform. And it's free!"
 tags = ["aws"," devops"]
 +++


### PR DESCRIPTION
Fix the thumbnail URL for bytebase.md, drovio.md, bitbucket-pipeline.md, lemon.md and atom.md