### PR TITLE
Remove practice.dev

### DIFF
--- a/content/stuff/practice-dev.md
+++ b/content/stuff/practice-dev.md
@@ -1,8 +1,0 @@
-+++
-date = 2021-09-09T15:28:15.110Z
-title = "Practice.dev"
-link = "https://practice.dev"
-thumbnail = "https://practice.dev/favicon.png"
-snippet="At practice.dev you can solve various frontend challenges in modern technologies like React. You can write code directly in the browser using an embedded VSCode, and your solution is automatically tested."
-tags = ["learning-resource"]
-+++


### PR DESCRIPTION
No longer maintained and website is not functional.
https://github.com/hilmanski/freeStuffDev/issues/1342
https://practice.dev/