### PR TITLE
Layout fixes

### DIFF
--- a/src/components/AllTags.astro
+++ b/src/components/AllTags.astro
@@ -84,12 +84,12 @@ const tags = Object.entries(tagCounts)
 
 <!-- Modal to show all tags -->
 <div id="modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50">
-    <div class="bg-white w-4/5 md:w-2/3 mx-auto mt-10 p-5 rounded-md">
+    <div class="bg-white w-4/5 md:w-2/3 mx-auto my-10 p-5 rounded-md max-h-[90%] overflow-y-scroll">
         <div class="flex justify-between">
-            <h2 class="text-lg font-bold">All Tags</h2>
+            <h2 class="text-lg font-bold text-gray-800">All Tags</h2>
             <button class="text-red-500" onclick="closeModal()">Close</button>
         </div>
-        <div class="flex flex-wrap gap-2 mt-3 overflow-y">
+        <div class="flex flex-wrap gap-2 mt-3">
             {
                 [...uniqueTags].map((tag) => (
                     <a href={`/tags/${tag.trim().toLowerCase()}`}

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -30,7 +30,7 @@ const { tool, isHidden = false } = Astro.props;
                 alt={`Logo thumbnail for ${tool.data.title}`}
                 width="80"
                 height="auto"
-                class="mr-5 min-w-[80px] max-h-[80px] max-w-[80px]"
+                class="mr-5 min-w-[80px] max-h-[80px] max-w-[80px] object-contain"
                 onerror="removeMe(this)"
                 loading="lazy"
                 />

--- a/src/layouts/Sidebar.astro
+++ b/src/layouts/Sidebar.astro
@@ -2,8 +2,7 @@
 import AllTags from '../components/AllTags.astro'
 ---
 
-<header id="sidebar">
-
+<header id="sidebar" class="overflow-y-scroll h-full z-10">
     <div class="flex md:block items-start">
         <a href="/">
         <img 


### PR DESCRIPTION
Hi, there are a few minor issues with page layout, decided to fix them.

1. Side bar is not scrollable, so on lower screen sizes it ends prematurely, added ability to scrol
2. All Tags modal is below content from the list, modified z-index to make it work
3. All Tags header in the modal is too light to be visible, changed text color
4. On lower screens All Tags modal can be longer than the page, added some margins and scroll to be better, although it could be improved more with a rewrite, so it would display and work better
5. Bigger logos display with incorrect aspect ratio (for example Zoho), added a class to preserve aspect ratio