### PR TITLE
Add boathouse.pro to freestuff.dev

### DIFF
--- a/src/content/tools/boathouse---pre-built-billing-add-ons-for-paddle-billing.md
+++ b/src/content/tools/boathouse---pre-built-billing-add-ons-for-paddle-billing.md
@@ -1,0 +1,12 @@
+---
+title: "Boathouse - Pre-Built Billing Add-Ons for Paddle Billing"
+link: "https://www.boathouse.pro"
+thumbnail: "https://assets-global.website-files.com/652922e69bff87e7694e38f0/653bd866e0a0ea46ba253bb8_android-chrome-256x256.png"
+snippet: "You create an amazing SaaS. Leave the customer billing portal, pricing tables and much more to us."
+tags: ["billing","customer portals","paddle","subscriptions","saas"]
+createdAt: 2024-03-26T13:41:26.267Z
+---
+Our customer portal and billing add-ons for Paddle Billing are free until you reach $500 MRR:
+- Ready-made self service customer portal for subscription and invoice management.
+- Embeddable dynamic pricing tables linked to Paddle prices with automatic currency conversion
+- Export various Paddle Data to CSV


### PR DESCRIPTION
Our customer portal is free for developers to use in their products until they reach $500 MRR.