### PR TITLE
Adding SyncThemCalendars to the list

### DIFF
--- a/src/content/tools/syncthemcalendars.md
+++ b/src/content/tools/syncthemcalendars.md
@@ -1,0 +1,12 @@
+---
+title: SyncThemCalendars
+link: https://syncthemcalendars.com
+thumbnail: >-
+  https://firebasestorage.googleapis.com/v0/b/syncalendars-pictures/o/GWM-Icon-128x128.png?alt=media&token=6cdba25b-7bc6-4d14-9056-e47e23032f53
+snippet: >-
+  SyncThemCalendars is a Saas software allowing to synchronize multiple calendars. 
+  Don't get overbooked anymore
+tags: ["google", "calendars", "sync"]
+createdAt: 2024-04-26T10:00:00+00:00
+---
+3x one-way synchronization


### PR DESCRIPTION
Hi, Please add SyncThemCalendars to the list.
I think it's valuable for devs working as freelance, as they often have multiple accounts (1/client) and need to ensure they don't get overbooked