### PR TITLE
Add Curl2Url

### DIFF
--- a/src/content/tools/curl2url.md
+++ b/src/content/tools/curl2url.md
@@ -1,0 +1,15 @@
+---
+createdAt: 2024-03-19T14:06:00.000Z
+title: Curl2Url
+link: https://curl2url.com/
+thumbnail: https://curl2url.com/android-chrome-192x192.png
+snippet: >-
+  Curl2Url is a curl execution service. With Curl2Url you can convert curl
+  to URLs, so when that URL is accessed, the CURL command is executed. You
+  can convert your curl commands to code like Python, Java, Kotlin and Rust.
+  You can use proxies from all over the world on each Curl
+tags: [ "api-testing", "api-test", "curl", "proxy", "curl-to-code", "curl-to-url" ]
+---
+Run curl commands online
+Convert Curl to URLs
+Convert Curl to code


### PR DESCRIPTION
Curl2Url is a curl execution service. With Curl2Url you can convert curl to URLs, so when that URL is accessed, the CURL command is executed. You can convert your curl commands to code like Python, Java, Kotlin and Rust. You can use proxies from all over the world on each Curl.