### PR TITLE
Updated Degoo Free Tier details

### DIFF
--- a/src/content/tools/degoo.md
+++ b/src/content/tools/degoo.md
@@ -8,4 +8,4 @@ snippet: >-
   iOS and web.
 tags: ["storage", " cloud-storage"]
 ---
-Free 100 GB cloud space
+Free 20 GB cloud space


### PR DESCRIPTION
Degoo now only provides 20GB of free cloud space instead of 100 as per their [pricing plans](https://degoo.com/me/chooseaccount)

A good alternative would be playbook.com that provides 4 TB of free storage to Creator Accounts & 100 GB for normal users for free