### PR TITLE
Fix Modal Behavior for "All Tags" Selection

### DIFF
--- a/src/components/AllTags.astro
+++ b/src/components/AllTags.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from 'astro:content'
+import { getCollection } from "astro:content";
 
-const tools = await getCollection('tools')
+const tools = await getCollection("tools");
 
 // Step 1: Extract all tags
-const allTags = tools.flatMap(obj => obj.data.tags);
+const allTags = tools.flatMap((obj) => obj.data.tags);
 
 // trim and lowercase tags
 allTags.forEach((tag, index) => {
@@ -12,78 +12,93 @@ allTags.forEach((tag, index) => {
 });
 const uniqueTags = new Set(allTags);
 
-
 // Step 2: Count tags
 const tagCounts = allTags.reduce((item: any, tag) => {
     item[tag] = (item[tag] || 0) + 1;
     return item;
 }, {}) as Record<string, number>;
 
-// Step 3: Sort and get top 
+// Step 3: Sort and get top
 const maxTags = 20;
 const tags = Object.entries(tagCounts)
     .sort((a, b) => b[1] - a[1])
     .slice(0, maxTags)
-    .map(item => item[0]);
-
+    .map((item) => item[0]);
 ---
-
-
 
 <script is:inline>
     function toggleBtnTags() {
-        const tagList = document.getElementById('tagList');
-        tagList.classList.toggle('hidden');
+        const tagList = document.getElementById("tagList");
+        tagList.classList.toggle("hidden");
     }
 
     // Toggle modal tags
     function showAllTags() {
-        document.getElementById('modal').classList.remove('hidden');
+        document.getElementById("modal").classList.remove("hidden");
     }
 
     function closeModal() {
-        document.getElementById('modal').classList.add('hidden');
+        document.getElementById("modal").classList.add("hidden");
     }
 
     window.showAllTags = showAllTags;
     window.closeModal = closeModal;
 </script>
 
-<div class="flex justify-between items-center lg:hidden mb-5
+<div
+    class="flex justify-between items-center lg:hidden mb-5
             py-2 boder border-y cursor-pointer"
-    onclick="toggleBtnTags()">
+    onclick="toggleBtnTags()"
+>
     <p>Show Categories</p>
-    <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-triangle-inverted" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10.363 20.405l-8.106 -13.534a1.914 1.914 0 0 1 1.636 -2.871h16.214a1.914 1.914 0 0 1 1.636 2.871l-8.106 13.534a1.914 1.914 0 0 1 -3.274 0z" /></svg>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="icon icon-tabler icon-tabler-triangle-inverted"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path
+            d="M10.363 20.405l-8.106 -13.534a1.914 1.914 0 0 1 1.636 -2.871h16.214a1.914 1.914 0 0 1 1.636 2.871l-8.106 13.534a1.914 1.914 0 0 1 -3.274 0z"
+        ></path></svg
+    >
 </div>
 
-
-<div class="hidden lg:block"
-    id="tagList">
+<div class="hidden lg:block" id="tagList">
     <p class="mb-3">Top {maxTags} Tags</p>
     <div class="flex flex-wrap gap-2 mb-5">
         {
             [...tags].map((tag) => (
-                <a href={`/tags/${tag.trim().toLowerCase()}`}
-                    class="bg-slate-700 text-white hover:text-white hover:bg-slate-900 
+                <a
+                    href={`/tags/${tag.trim().toLowerCase()}`}
+                    class="bg-slate-700 text-white hover:text-white hover:bg-slate-900
                         px-1 py-1 rounded-md text-xs"
-                    >
+                >
                     {tag}
                 </a>
             ))
         }
     </div>
 
-<div>
-    <button 
-        class="w-full bg-gray-400 hover:bg-gray-200 text-gray-800 px-3 py-1 rounded-md text-sm"
-        onclick="showAllTags()">
-        Show all tags
-    </button>
-</div>
+    <div>
+        <button
+            class="w-full bg-gray-400 hover:bg-gray-200 text-gray-800 px-3 py-1 rounded-md text-sm"
+            onclick="showAllTags()"
+        >
+            Show all tags
+        </button>
+    </div>
 </div>
 
 <!-- Modal to show all tags -->
-<div id="modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50">
+<div
+    id="modal"
+    class="hidden fixed inset-0 bg-black bg-opacity-z-50 overflow-auto"
+>
     <div class="bg-white w-4/5 md:w-2/3 mx-auto mt-10 p-5 rounded-md">
         <div class="flex justify-between">
             <h2 class="text-lg font-bold">All Tags</h2>
@@ -92,9 +107,10 @@ const tags = Object.entries(tagCounts)
         <div class="flex flex-wrap gap-2 mt-3 overflow-y">
             {
                 [...uniqueTags].map((tag) => (
-                    <a href={`/tags/${tag.trim().toLowerCase()}`}
+                    <a
+                        href={`/tags/${tag.trim().toLowerCase()}`}
                         class="bg-gray-200 text-gray-800 px-1 py-1 rounded-md text-xs"
-                        >
+                    >
                         {tag}
                     </a>
                 ))

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,24 +1,27 @@
 ---
-
 const { tool, isHidden = false } = Astro.props;
 ---
 
 <script is:inline>
     function removeMe(el) {
-        const div = document.createElement('div');
-        div.style.width = '100px';
+        const div = document.createElement("div");
+        div.style.width = "100px";
         el.replaceWith(div);
     }
 </script>
 
-<div class=`${isHidden ? 'hidden' : ''}
-    cards mb-10 text-sm border-b border-b-slate-600 pb-5 relative`>
-    <input type="hidden" name="tool-slug" value={tool.slug}>
+<div
+    class=`${isHidden ? 'hidden' : ''}
+    cards mb-10 text-sm border-b border-b-slate-600 pb-5`
+>
+    <input type="hidden" name="tool-slug" value={tool.slug} />
 
     {
         tool.data.isPaid && (
-            <div class="bg-rose-500 text-white px-2 py-1 ml-5 rounded-md 
-                absolute right-0">
+            <div
+                class="bg-rose-500 text-white px-2 py-1 ml-5 rounded-md
+                absolute right-0"
+            >
                 Paid Tool
             </div>
         )
@@ -26,45 +29,60 @@ const { tool, isHidden = false } = Astro.props;
 
     <div class="block md:flex justify-between">
         <div class="flex">
-            <img src={tool.data.thumbnail} 
+            <img
+                src={tool.data.thumbnail}
                 alt={`Logo thumbnail for ${tool.data.title}`}
                 width="80"
                 height="auto"
                 class="mr-5 min-w-[80px] max-h-[80px] max-w-[80px]"
                 onerror="removeMe(this)"
                 loading="lazy"
-                />
+            />
 
             <div>
                 <p class="text-2xl mb-2">{tool.data.title}</p>
                 <p class="max-w-[500px]">{tool.data.snippet}</p>
 
-                <p class="mt-5">Tags: {tool.data.tags.join(', ')}</p>
+                <p class="mt-5">Tags: {tool.data.tags.join(", ")}</p>
             </div>
         </div>
 
         {
             tool.body && (
-                <div class="whitespace-pre-line text-left md:text-right 
-                            mt-5 md:mt-0 mb-5 md:mb-0">
+                <div
+                    class="whitespace-pre-line text-left md:text-right
+                            mt-5 md:mt-0 mb-5 md:mb-0"
+                >
                     <p>Free Offer:</p>
 
-                    <div>
-                        {tool.body}
-                    </div>
+                    <div>{tool.body}</div>
                 </div>
             )
         }
     </div>
 
-
     <div class="mt-2 flex space-x-5 justify-end">
-        <a class="unsave-button hidden"
-           href="#" onclick=`unsave(event, "${tool.slug}")`> Remove from Favorites </a>
-        <a class="save-button"
-           href="#" onclick=`save(event, "${tool.slug}")`>Save</a>
-        <a target="_blank" rel="noopener nofollow" href={`https://github.com/hilmanski/freeStuffDev/edit/main/src/content/tools/${tool.slug}.md`}>Edit</a>
-        <a target="_blank" rel="noopener nofollow" href={`${tool.data.link}?utm_source=freestuffdev`}>Visit</a>
+        <a
+            class="unsave-button hidden"
+            href="#"
+            onclick=`unsave(event, "${tool.slug}")`
+        >
+            Remove from Favorites
+        </a>
+        <a class="save-button" href="#" onclick=`save(event, "${tool.slug}")`
+            >Save</a
+        >
+        <a
+            target="_blank"
+            rel="noopener nofollow"
+            href={`https://github.com/hilmanski/freeStuffDev/edit/main/src/content/tools/${tool.slug}.md`}
+            >Edit</a
+        >
+        <a
+            target="_blank"
+            rel="noopener nofollow"
+            href={`${tool.data.link}?utm_source=freestuffdev`}>Visit</a
+        >
         <a href={`/alternative/${tool.slug}`}>Alternatives</a>
     </div>
 </div>


### PR DESCRIPTION
This pull request addresses an issue with the "All Tags" modal and includes some minor formatting changes.

Problem: When opening the "All Tags" modal, it behaves unexpectedly (see attached image). The following issues were observed:

The modal doesn't allow the selection of any tags.
The modal cannot be closed properly.
Scrolling is disabled, making it impossible to access tags further down.
Changes Made:

1. Added overflow-auto to the modal for improved scrolling functionality:
```html
<div
    id="modal"
    class="hidden fixed inset-0 bg-black bg-opacity-z-50 overflow-auto"
```
2. Removed relative from the class definition to ensure proper display:
```html 
<div
    class={`${isHidden ? 'hidden' : ''} cards mb-10 text-sm border-b border-b-slate-600 pb-5`}

```
Note: Some formatting changes have been applied, which may affect other areas of the code. Please review to ensure no unintended modifications were introduced.

Let me know if any further adjustments are needed!

<img width="979" alt="image" src="https://github.com/user-attachments/assets/4c00c654-ee2d-44e9-8db2-6053547bf4fe">

