### PR TITLE
Fix positioning of main container on large screens

### DIFF
--- a/src/styles/main.sass
+++ b/src/styles/main.sass
@@ -2,15 +2,15 @@
 @tailwind components
 @tailwind utilities
 
-body 
+body
     background: #363940
     color: #F6F7F9
     font-size: 16px
 
-a 
-    color: #f6bfd4 
-    &:hover 
-        color: #f08383 
+a
+    color: #f6bfd4
+    &:hover
+        color: #f08383
 
 #sidebar
     min-width: 350px
@@ -41,10 +41,10 @@ main
 
 @media screen and (min-width: 1300px)
     main
-        margin-left: 400px
+        margin-left: max(calc(20% + 50px), 350px)
 
 
-//  Responsive mobile size    
+//  Responsive mobile size
 @media screen and (max-width: 768px)
     .sponsors
         a


### PR DESCRIPTION
Ensures that the left margin on the main container is correctly alignment with the sidebar on large screens.

Before fix:
![CleanShot 2025-02-12 at 12 15 20](https://github.com/user-attachments/assets/aaeceefd-73bb-49de-9008-c97e8e33cc97)

After fix:
![CleanShot 2025-02-12 at 12 14 50](https://github.com/user-attachments/assets/16fb6ba1-7cf1-4f0c-86ea-0064d84a4c9a)
