### PR TITLE
Correct putty URL

### DIFF
--- a/src/content/tools/putty.md
+++ b/src/content/tools/putty.md
@@ -1,7 +1,7 @@
 ---
 title: PuTTY
-link: https://www.putty.org/
-thumbnail: https://www.putty.org/Putty.png
+link: https://www.chiark.greenend.org.uk/~sgtatham/putty/
+thumbnail: https://www.chiark.greenend.org.uk/~sgtatham/putty/putty.ico
 snippet: PuTTY is an SSH and telnet client, developed originally by Simon Tatham for the Windows platform.
 tags: ["SSH"]
 createdAt: 2021-06-26T00:00:00.000Z


### PR DESCRIPTION
Hello,
Nice website.
`putty.org` is not affiliated with the putty developers, they squat the domain name with a higher SEO ranking and push adware along with putty.
There are also rumors of them distributing malware.

The official website is https://www.chiark.greenend.org.uk/~sgtatham/putty/

Source: https://hachyderm.io/@simontatham/114846017785770922 (The developer's Fediverse account).