### PR TITLE
Add DeployHQ

### DIFF
--- a/src/content/tools/deployhq.md
+++ b/src/content/tools/deployhq.md
@@ -1,0 +1,17 @@
+---
+title: DeployHQ
+link: https://www.deployhq.com/
+thumbnail: https://www.deployhq.com/apple-touch-icon.png
+snippet: >-
+  Automated Git deployment to your servers — atomic releases, one-click
+  rollback, zero downtime. No YAML, no Docker required.
+tags: ["CI-CD", "deployment"]
+createdAt: 2026-05-01T00:00:00.000Z
+---
+1 project
+5 servers
+1 user
+3 deployments per day
+Deploy from GitHub, GitLab, Bitbucket, Mercurial, SVN
+Atomic deploys with one-click rollback
+Email support


### PR DESCRIPTION
Adding **DeployHQ** to the tools list — automated Git deployment service with a free tier (1 project, 5 servers, 1 user, 3 deployments per day).

DeployHQ has been around since 2010 and is in the same category as the existing `buddy-works.md` entry (CI-CD + deployment), so I followed that file's format and tag conventions.

### Free tier (verified at deployhq.com/pricing)
- 1 project
- 5 servers
- 1 user
- 3 deployments per day
- Deploy from GitHub, GitLab, Bitbucket, Mercurial, SVN
- Atomic deploys with one-click rollback
- Email support

### Rules check
- ✅ Free tier (rule 1: free or 1y trial)
- ✅ Not language/framework-specific
- ✅ Not a doc/forum link
- ✅ Service link, not "themes for" or library

Happy to adjust the snippet, tags, or feature list if you'd like a different framing.