### PR TITLE
Add Seitengrat Revenue Leak Scan

### DIFF
--- a/src/content/tools/seitengrat-revenue-leak-scan.md
+++ b/src/content/tools/seitengrat-revenue-leak-scan.md
@@ -1,0 +1,9 @@
+---
+title: Seitengrat Revenue Leak Scan
+link: https://seitengrat.com/quick-scan.html
+thumbnail: https://seitengrat.com/assets/seitengrat-logo.svg
+snippet: Free no-login scan that checks public pages for conversion, trust, offer, checkout, and buyer-action leaks.
+tags: ["devtools", "analytics", "website", "seo"]
+createdAt: 2026-05-11T00:00:00.000Z
+---
+Free no-login public page scan for conversion, trust, offer, checkout, and buyer-action signals. Paste a URL and get a structured report with concrete fixes; a paid manual audit is optional.


### PR DESCRIPTION
Adds Seitengrat Revenue Leak Scan, a free no-login public-page scanner for conversion, trust, offer, checkout, and buyer-action leaks.\n\nFree benefit: paste a URL and get a structured report with concrete fixes. A paid manual audit is optional and not required to use the free scan.\n\nValidation:\n- Ran `corepack yarn install --frozen-lockfile` successfully.\n- `corepack yarn build` is currently blocked by an existing upstream content parse error in `src/content/tools/poof.md` ("can not read a block mapping entry; a multiline key may not be an implicit key"). This PR only adds one new markdown listing file.