### PR TITLE
Add 3 free Mac display tools (PPI, cable bandwidth, external display support)

### DIFF
--- a/src/content/tools/mac-cable-bandwidth-calculator.md
+++ b/src/content/tools/mac-cable-bandwidth-calculator.md
@@ -1,0 +1,10 @@
+---
+title: Mac Cable Bandwidth Calculator
+link: https://retinadesk.com/tools/cable-bandwidth-calculator/
+snippet: Check whether a USB-C, HDMI, DisplayPort, or Thunderbolt cable has the bandwidth to drive 4K120, 5K60, 6K, and more on a Mac.
+tags: ["Mac", "Display", "Calculator", "Hardware"]
+createdAt: 2026-06-04T00:00:00.000Z
+---
+Free, no signup, runs entirely in your browser.
+
+Pick a cable type and a target resolution/refresh rate to see whether the link has enough bandwidth — so you stop guessing why your monitor won't hit 4K120 or 5K60.

--- a/src/content/tools/mac-external-display-support.md
+++ b/src/content/tools/mac-external-display-support.md
@@ -1,0 +1,10 @@
+---
+title: Mac External Display Support
+link: https://retinadesk.com/tools/external-display-support/
+snippet: Reference showing how many external displays each Apple Silicon Mac (M1 to M5) can drive, with per-port resolutions and refresh rates.
+tags: ["Mac", "Display", "Reference", "Hardware"]
+createdAt: 2026-06-04T00:00:00.000Z
+---
+Free, no signup, runs entirely in your browser.
+
+Look up the exact external-display limits for any Apple Silicon Mac — maximum display count, supported resolutions, and refresh rates per port — before you buy a monitor or dock.

--- a/src/content/tools/mac-ppi-calculator.md
+++ b/src/content/tools/mac-ppi-calculator.md
@@ -1,0 +1,10 @@
+---
+title: Mac PPI Calculator & Retina Checker
+link: https://retinadesk.com/tools/ppi-calculator/
+snippet: Calculate any monitor's pixel density and instantly check whether it renders Retina-sharp on macOS, with a HiDPI scaling preview.
+tags: ["Mac", "Display", "Calculator", "Design"]
+createdAt: 2026-06-04T00:00:00.000Z
+---
+Free, no signup, runs entirely in your browser.
+
+Enter a display's resolution and physical size to get its exact PPI (pixels per inch), see whether macOS will treat it as a Retina-class display, and preview how HiDPI scaling will look. Handy when choosing or speccing an external monitor for a Mac.


### PR DESCRIPTION
🖥️ Three **free**, no-signup, browser-based tools — each as its own file in `src/content/tools/` per the contributing guide:

- **[Mac PPI Calculator & Retina Checker](https://retinadesk.com/tools/ppi-calculator/)** — pixel density + Retina-sharpness on macOS, with HiDPI scaling preview. 🔍
- **[Mac Cable Bandwidth Calculator](https://retinadesk.com/tools/cable-bandwidth-calculator/)** — can this cable push 4K120 / 5K60 / 6K? ⚡
- **[Mac External Display Support](https://retinadesk.com/tools/external-display-support/)** — display limits per Apple Silicon Mac (M1–M5). 🧩

✅ One `.md` file per tool · valid frontmatter (title, link, snippet, tags, createdAt) · genuinely free (no trial wall, so no `isPaid`)
✅ Standalone web tools — not framework-specific, not a library or docs link

Each one gets its own rendered page on freestuff.dev — hope they're a great fit! 🙌