### PR TITLE
Add Noiseloop

### DIFF
--- a/src/content/tools/noiseloop.md
+++ b/src/content/tools/noiseloop.md
@@ -1,0 +1,16 @@
+---
+title: "Noiseloop"
+link: "https://noiseloop.app"
+thumbnail: "https://noiseloop.app/apple-touch-icon.png"
+snippet: "Mix rain, white noise, brown noise and nature sounds with a built-in Pomodoro timer. Free ambient sound mixer for focus, study and deep work."
+tags: ["productivity","utilities"]
+createdAt: 2026-06-07T11:36:05.231Z
+---
+- 100% free with no ads, no registration, and no tracking.
+- Interactive sound mixer to layer ambient tracks (rain, white/brown noise, forest, thunder).
+- Independent volume controls for every background sound layer.
+- 4 instant preset modes: Noise Blocker, Deep Work, Relax, and Light Work.
+- Seamless, gapless playback switching between sound profiles.
+- Integrated productivity timer (25, 45, 60, 90 mins) with a gentle end chime.
+- Live countdown timer displayed directly in the browser tab title.
+- Reliable background playback with automatic browser interruption recovery.


### PR DESCRIPTION
Hi @hilmanski! 👋

I'd like to add **Noiseloop** to freestuff.dev. It's a completely free ambient sound mixer and session timer built to help developers and creators enter a deep focus state instantly.

**Why it fits freestuff.dev perfectly:**
- **Truly Free:** No subscription and absolutely no ads. 
- **Privacy-Friendly:** No sign-up or email required. Your focus sessions, timer settings, and sound preferences are stored locally in your browser.
- **Developer Friendly:** Includes an interactive sound mixer, curated presets (Noise Blocker, Deep Work), and a tab-integrated countdown timer so you don't have to switch contexts.

I have followed the contribution guidelines, used valid tags, structured the features list line-by-line, and provided a proper thumbnail URL.

Thank you for maintaining this awesome resource! Let me know if any changes are needed.