### PR TITLE
Add Year Holidays

### DIFF
--- a/src/content/tools/yearholidays.md
+++ b/src/content/tools/yearholidays.md
@@ -1,0 +1,9 @@
+---
+title: "Year Holidays"
+link: "https://yearholidays.com/"
+thumbnail: "https://yearholidays.com/favicon.png"
+snippet: "A free 2026 US public holiday calendar with federal holidays, observed dates, FAQs, and an ICS calendar download."
+tags: ["productivity", "learning-resource"]
+createdAt: 2026-06-10T00:00:00.000Z
+---
+Free US public holiday calendar for 2026, including federal holiday dates, observed dates, FAQs, and an ICS calendar download for planning work, travel, payroll, school schedules, and vacations.


### PR DESCRIPTION
Adds Year Holidays, a free 2026 US public holiday calendar with observed dates, FAQs, and an ICS download.