### PR TITLE
Add yamltojson.dev — free YAML/XML/CSV to JSON converters

### DIFF
--- a/src/content/tools/yamltojson.md
+++ b/src/content/tools/yamltojson.md
@@ -1,0 +1,10 @@
+---
+createdAt: 2026-06-13T00:00:00.000Z
+title: YAML, XML & CSV to JSON Converters
+link: https://yamltojson.dev/
+thumbnail: https://www.google.com/s2/favicons?domain=yamltojson.dev&sz=128
+snippet: >-
+  Free in-browser converters for developers: YAML to JSON (and back), XML to
+  JSON, JSON to CSV and CSV to JSON. Instant, no signup, nothing uploaded.
+tags: ["json", "yaml", "converter"]
+---


### PR DESCRIPTION
Adds [yamltojson.dev](https://yamltojson.dev/), a set of free, no-signup, in-browser data format converters for developers: YAML↔JSON, XML↔JSON, JSON↔CSV and CSV↔JSON.

- 100% free, no signup, runs client-side (nothing uploaded)
- Not language/framework specific — a standalone online tool, in line with the existing JSON/format tools already listed (jsonformatter, freeformatter, format-express, cloudconvert)

New file: `src/content/tools/yamltojson.md`