### PR TITLE
Add 9 free in-browser tool sites (MathLab, ColorKit, ConverterKit, DateTime, HealthFit, ImgLab, NetChecks, Picker, WordCraft)

### DIFF
--- a/src/content/tools/colorkit-tools.md
+++ b/src/content/tools/colorkit-tools.md
@@ -1,0 +1,9 @@
+---
+title: "ColorKit Tools"
+link: "https://colorkit.tools/"
+thumbnail: "https://colorkit.tools/favicon.ico"
+snippet: "Color tools for designers: palette generator, picker, gradient maker, hex/RGB converter, WCAG contrast."
+tags: ["color-picker", "design-tools", "web-development"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+ColorKit Tools is a set of color utilities for designers and developers. It includes a palette generator, color picker, gradient maker, hex/RGB/HSL converter, and a WCAG contrast checker for accessibility. All tools work in the browser with no signup.

--- a/src/content/tools/converterkit.md
+++ b/src/content/tools/converterkit.md
@@ -1,0 +1,9 @@
+---
+title: "ConverterKit Tools"
+link: "https://converterkit.tools/"
+thumbnail: "https://converterkit.tools/favicon.ico"
+snippet: "Unit converters: currency, length, weight, temperature, cooking measurements, area, volume, speed."
+tags: ["unit-converter", "converter", "calculator"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+ConverterKit Tools is a collection of unit converters covering currency, length, weight, temperature, cooking measurements, area, volume, and speed. Convert between units instantly in your browser with no signup required.

--- a/src/content/tools/datetime.md
+++ b/src/content/tools/datetime.md
@@ -1,0 +1,9 @@
+---
+title: "DateTime Tools"
+link: "https://datetime.tools/"
+thumbnail: "https://datetime.tools/favicon.ico"
+snippet: "Date & time tools: timezone converter, stopwatch, age calculator, countdown, Unix timestamp, Discord timestamp."
+tags: ["time", "productivity", "developer-tools"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+DateTime Tools is a collection of date and time utilities including a timezone converter, stopwatch, age calculator, countdown timer, Unix timestamp converter, and a Discord timestamp generator. Handy for developers and anyone coordinating across time zones, all free in the browser.

--- a/src/content/tools/healthfit.md
+++ b/src/content/tools/healthfit.md
@@ -1,0 +1,9 @@
+---
+title: "HealthFit"
+link: "https://healthfit.tools/"
+thumbnail: "https://healthfit.tools/favicon.ico"
+snippet: "Health & fitness calculators: BMI, BMR, TDEE, body fat, due date, ovulation. Educational only."
+tags: ["health", "fitness", "calculator"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+HealthFit is a free set of health and fitness calculators for estimating BMI, BMR, TDEE, and body fat, along with pregnancy due date and ovulation calculators. The tools are educational only and not a substitute for professional medical advice. Everything runs in your browser with no signup.

--- a/src/content/tools/imglab.md
+++ b/src/content/tools/imglab.md
@@ -1,0 +1,9 @@
+---
+title: "ImgLab Tools"
+link: "https://imglab.tools/"
+thumbnail: "https://imglab.tools/favicon.ico"
+snippet: "Browser-based image converters (HEIC, PNG, WebP), compressor, resizer, favicon generator. Files stay on your device."
+tags: ["image-converter", "image-editor", "photo"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+ImgLab Tools is a set of browser-based image utilities that process files locally so nothing is uploaded to a server. It includes converters for HEIC, PNG, JPG and WebP, plus an image compressor, a resizer, and a favicon generator. All tools run entirely on your device for privacy.

--- a/src/content/tools/mathlab.md
+++ b/src/content/tools/mathlab.md
@@ -1,0 +1,9 @@
+---
+title: "MathLab"
+link: "https://mathlab.tools/"
+thumbnail: "https://mathlab.tools/favicon.ico"
+snippet: "Math tools: scientific calculator, equation solver, matrix/fraction, statistics, graphing."
+tags: ["math", "calculator", "education"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+MathLab is a free collection of math tools including a scientific calculator, equation solver, matrix and fraction calculators, a statistics calculator, and a graphing tool. Useful for students and anyone doing quick math, all in the browser.

--- a/src/content/tools/netchecks.md
+++ b/src/content/tools/netchecks.md
@@ -1,0 +1,9 @@
+---
+title: "NetChecks"
+link: "https://netchecks.tools/"
+thumbnail: "https://netchecks.tools/favicon.ico"
+snippet: "Network diagnostics: IP lookup, DNS, WHOIS, ping, port checker, SSL checker, MAC vendor lookup."
+tags: ["network-tools", "dns", "ip-tools"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+NetChecks is a free suite of network diagnostic tools for developers and admins. It covers IP lookup, DNS records, WHOIS, ping, port checking, SSL certificate inspection, and MAC vendor lookup. Run quick checks directly from your browser without installing anything.

--- a/src/content/tools/picker.md
+++ b/src/content/tools/picker.md
@@ -1,0 +1,9 @@
+---
+title: "Picker Tools"
+link: "https://picker.tools/"
+thumbnail: "https://picker.tools/favicon.ico"
+snippet: "Random pickers and decision tools: wheel of names, dice, coin flip, random number/word/letter."
+tags: ["random-generator", "decision-maker", "productivity"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+Picker Tools is a collection of random pickers and decision-making utilities. It includes a wheel of names, dice roller, coin flip, and random number, word, and letter generators. Use it to make quick fair choices or break ties, all free in the browser.

--- a/src/content/tools/wordcraft.md
+++ b/src/content/tools/wordcraft.md
@@ -1,0 +1,9 @@
+---
+title: "WordCraft Text Tools"
+link: "https://wordcraft.tools/"
+thumbnail: "https://wordcraft.tools/favicon.ico"
+snippet: "Text tools: fancy text generators (cursive, glitch, bold), word counter, case converter, novelty translators."
+tags: ["text-tools", "text-generator", "writing"]
+createdAt: 2026-06-23T00:00:00.000Z
+---
+WordCraft Text Tools is a set of text utilities including fancy text generators (cursive, glitch, bold Unicode styles), a word and character counter, a case converter, and novelty translators. Useful for social media, writing, and formatting, all free in the browser.


### PR DESCRIPTION
Adding a family of free, no-signup, in-browser tool sites. Each runs client-side with no account required:

- **MathLab** (https://mathlab.tools/) — scientific calculator, equation/matrix/fraction solvers, statistics, graphing
- **ColorKit Tools** (https://colorkit.tools/) — palette generator, picker, gradient maker, hex/RGB converter, WCAG contrast (filename colorkit-tools.md since colorkit.md is taken)
- **ConverterKit Tools** (https://converterkit.tools/) — unit converters (currency, length, weight, temperature, cooking, area, volume, speed)
- **DateTime Tools** (https://datetime.tools/) — timezone converter, stopwatch, age calculator, countdown, Unix/Discord timestamps
- **HealthFit** (https://healthfit.tools/) — BMI/BMR/TDEE/body-fat and pregnancy calculators (educational)
- **ImgLab Tools** (https://imglab.tools/) — local image converters (HEIC/PNG/WebP), compressor, resizer, favicon generator
- **NetChecks** (https://netchecks.tools/) — IP/DNS/WHOIS/ping/port/SSL/MAC-vendor lookups
- **Picker Tools** (https://picker.tools/) — wheel of names, dice, coin flip, random number/word/letter
- **WordCraft Text Tools** (https://wordcraft.tools/) — fancy text generators, word counter, case converter

Grouped into one PR to keep review simple; happy to split if preferred.