### PR TITLE
Add Bargo Congress Trades API

### DIFF
--- a/src/content/tools/bargo-congress-trades-api.md
+++ b/src/content/tools/bargo-congress-trades-api.md
@@ -1,0 +1,12 @@
+---
+title: "Bargo Congress Trades API"
+link: "https://www.bargo.ai/free-apis/congress"
+thumbnail: "https://www.bargo.ai/favicon.svg"
+snippet: "Free U.S. House and Senate stock-trade disclosure API with per-trade performance, REST endpoints, open CORS, and MCP support."
+tags: ["api", "finance", "data"]
+createdAt: 2026-07-02T20:40:00.000Z
+---
+30 keyless requests/day and 1,000 rows/day per IP
+1,000 requests/day and 25,000 rows/day with a free API key
+No credit card required
+REST API, open CORS, and MCP server


### PR DESCRIPTION
Adds Bargo Congress Trades API to FreeStuffDev.

Free tier limits from the docs:
- Keyless: 30 requests/day and 1,000 rows/day per IP
- Free API key: 1,000 requests/day and 25,000 rows/day

No credit card required.
