### PR TITLE
Add host-html (static HTML hosting)

### DIFF
--- a/src/content/tools/host-html.md
+++ b/src/content/tools/host-html.md
@@ -1,0 +1,14 @@
+---
+title: "host-html"
+link: "https://host-html.com"
+thumbnail: "https://host-html.com/favicon-32x32.png"
+snippet: "Paste or drop an HTML file and get an instant live link. Built for hosting AI-generated HTML (ChatGPT, Claude, v0, Bolt); open publish API."
+tags: ["hosting", "hosting-static"]
+createdAt: 2026-07-16T00:00:00.000Z
+---
+Free plan (requires a free, verified account)
+Free pages live 10 days
+Paste code or drop a single HTML file, get a link like host-html.com/p/abc123
+No Git, build tools, or config
+Open publish API for AI agents and scripts
+$2 one-time to keep a page forever; Pro $5/mo; Team $19/mo


### PR DESCRIPTION
Adds **host-html** to the tools list under `hosting` / `hosting-static`.

[host-html.com](https://host-html.com) turns a single HTML file into a live link — paste the code or drop the file and you get a link like `host-html.com/p/abc123`, no Git, build step, or config. It targets the "an AI just generated an HTML page and I need to share it" workflow (ChatGPT, Claude, v0, Bolt) and has an open publish API for agents/scripts.

Free tier requires a free, verified account and pages last 10 days; paid plans keep them forever. Followed the existing `src/content/tools/*.md` frontmatter schema (mirrored `tiiny_host.md`).

Disclosure: I'm on the host-html team — happy to adjust wording, tags, or the entry if anything doesn't fit the directory's conventions.