### PR TITLE
Add Appish - free Docker container hosting

### DIFF
--- a/src/content/tools/appish.md
+++ b/src/content/tools/appish.md
@@ -1,0 +1,11 @@
+---
+title: Appish
+link: https://appi.sh/
+thumbnail: https://appi.sh/images/logo_500x500_transparent.png
+snippet: >-
+  Free Docker container hosting for demos, MCP servers and side projects. Push
+  a Docker image, get a public HTTPS URL in 30 seconds — no servers, no YAML,
+  no CI/CD.
+tags: ["hosting", "docker", "container", "deployment", "deploy"]
+createdAt: 2026-07-21T00:00:00.000Z
+---


### PR DESCRIPTION
This PR adds Appish (https://appi.sh) to the tools list.
Appish is a free Docker container hosting service for demos, remote MCP
servers and side projects: you push a Docker image and get a public HTTPS
URL in about 30 seconds — no servers, no YAML, no CI/CD setup.
Free tier: one hosting slot, up to 2 hours per run, public HTTPS URL,
no credit card required.