### PR TITLE
Add FreeHosts

### DIFF
--- a/src/content/tools/freehosts.md
+++ b/src/content/tools/freehosts.md
@@ -1,0 +1,11 @@
+---
+date = "2026-07-21T00:00:00+00:00"
+tags = ["hosting", "hosting-static", "hosting-dynamic"]
+title="FreeHosts"
+link = "https://freehosts.eu"
+thumbnail = "https://freehosts.eu/Src/Images/banner.png"
+snippet="Community-curated directory of free hosting providers for websites, apps, bots, and databases"
+---
+Community reviews and staff picks
+Feature and plan comparisons across 100+ hosts
+Free to use, no signup required to browse

--- a/src/content/tools/freehosts.md
+++ b/src/content/tools/freehosts.md
@@ -1,11 +1,11 @@
 ---
-date = "2026-07-21T00:00:00+00:00"
-tags = ["hosting", "hosting-static", "hosting-dynamic"]
-title="FreeHosts"
-link = "https://freehosts.eu"
-thumbnail = "https://freehosts.eu/Src/Images/banner.png"
-snippet="Community-curated directory of free hosting providers for websites, apps, bots, and databases"
+title: "FreeHosts"
+link: "https://freehosts.eu"
+thumbnail: "https://freehosts.eu/Src/Images/banner.png"
+snippet: "Community-curated directory of free hosting providers for websites, apps, bots, and databases"
+tags: ["hosting","hosting-static","hosting-dynamic"]
+createdAt: 2026-07-21T21:55:54+01:00
 ---
-Community reviews and staff picks
+Community reviews
 Feature and plan comparisons across 100+ hosts
 Free to use, no signup required to browse

--- a/src/content/tools/freehosts.md
+++ b/src/content/tools/freehosts.md
@@ -1,9 +1,9 @@
 ---
 title: "FreeHosts"
 link: "https://freehosts.eu"
-thumbnail: "https://freehosts.eu/Src/Images/banner.png"
+thumbnail: "https://freehosts.eu/Src/icons/icon.png"
 snippet: "Community-curated directory of free hosting providers for websites, apps, bots, and databases"
-tags: ["hosting","hosting-static","hosting-dynamic"]
+tags: ["awesome-list","other-resources","hosting","hosting-static","hosting-dynamic"]
 createdAt: 2026-07-21T21:55:54+01:00
 ---
 Community reviews


### PR DESCRIPTION
FreeHosts is a community-curated directory that helps developers quickly find free hosting providers for websites, apps, bots, and databases — with community reviews and feature comparisons to save time versus researching each provider individually. 