### PR TITLE
Add Blank Space Copy - free invisible character tool

### DIFF
--- a/src/content/tools/blank-space-copy.md
+++ b/src/content/tools/blank-space-copy.md
@@ -1,0 +1,13 @@
+---
+title: "Blank Space Copy"
+link: "https://blankspacecopy.net"
+thumbnail: "https://blankspacecopy.net/icon-512x512.png"
+snippet: "Copy and paste blank space and invisible characters (U+3164, U+2800, U+200B) for Discord names, Instagram bios, and WhatsApp messages."
+tags: ["text-utils", "productivity"]
+createdAt: 2026-08-13T00:00:00.000Z
+---
+Free to use with no signup
+Copy blank space and invisible characters in one click
+Includes Hangul filler (U+3164), Braille blank (U+2800), zero-width space (U+200B)
+Works for Discord blank names, Instagram bios, WhatsApp blank messages
+Invisible character detector and cleaner


### PR DESCRIPTION
Adds Blank Space Copy (https://blankspacecopy.net) to the free tools directory.

- Free to use, no signup required
- Copy blank space and invisible characters (U+3164, U+2800, U+200B)
- Useful for Discord blank names, Instagram bios, WhatsApp blank messages

It is a permanently free web tool, fitting the free stuff for developers criteria.