### PR TITLE
Add CSR.plus to tools

### DIFF
--- a/src/content/tools/csr-plus.md
+++ b/src/content/tools/csr-plus.md
@@ -1,0 +1,11 @@
+---
+createdAt: 2026-08-16T08:00:00.000Z
+title: CSR.plus
+link: https://csr.plus/
+thumbnail: >-
+  https://dev-to-uploads.s3.amazonaws.com/uploads/articles/aedg7ai89dzudh6z3ose.png
+snippet: >-
+  Generate certificate signing requests and private keys in the browser (RSA,
+  ECDSA, Ed25519) with a free no-sign-up API. No OpenSSL needed.
+tags: ["security", "api", "ssl"]
+---


### PR DESCRIPTION
CSR.plus: generate certificate signing requests and private keys entirely in the browser (RSA, ECDSA, Ed25519). Free, unlimited, no sign-up; also offers a free API for developers. Fits the security/api tags.