### PR TITLE
Add MonitorFlare to tools

### DIFF
--- a/src/content/tools/monitorflare.md
+++ b/src/content/tools/monitorflare.md
@@ -1,0 +1,12 @@
+---
+createdAt: 2026-08-16T08:00:00.000Z
+title: MonitorFlare
+link: https://monitorflare.csr.plus/
+thumbnail: >-
+  https://dev-to-uploads.s3.us-east-2.amazonaws.com/uploads/articles/i5dq4w8wtm9a0gjyps39.png
+snippet: >-
+  Zero-cost uptime monitoring and public status page running entirely on
+  Cloudflare's free tier. Self-hosted, one-click deploy, 9 notification
+  channels and 9 languages.
+tags: ["monitoring", "uptime", "cloudflare"]
+---


### PR DESCRIPTION
MonitorFlare: zero-cost uptime monitoring and public status page on the Cloudflare free tier. Self-hosted (Workers + D1 + Pages), one-click deploy, 9 notification channels, 9 languages, MIT licensed. Live demo: https://monitorflare.csr.plus/