### PR TITLE
Add IdeaFast

### DIFF
--- a/src/content/tools/ideafast.md
+++ b/src/content/tools/ideafast.md
@@ -11,3 +11,6 @@ createdAt: 2026-08-18T00:00:00.000Z
 1 free Reddit pain point scan
 Scan covers 1 subreddit over a 30-day window
 3 evidence quotes and 2 startup ideas per pain point found
+Plus 11 free tools with no signup or card
+MRR, churn, LTV, CAC, TAM SAM SOM and Reddit API cost calculators
+Subreddit finder, Reddit keyword generator, AI idea generators and idea evaluator

--- a/src/content/tools/ideafast.md
+++ b/src/content/tools/ideafast.md
@@ -1,0 +1,13 @@
+---
+title: IdeaFast
+link: https://www.ideafast.pro
+thumbnail: https://www.ideafast.pro/apple-touch-icon.png
+snippet: >-
+  Find real customer pain points on Reddit, scored and backed by evidence, and
+  turn them into validated startup ideas.
+tags: ["research", "user-research", "AI", "saas"]
+createdAt: 2026-08-18T00:00:00.000Z
+---
+1 free Reddit pain point scan
+Scan covers 1 subreddit over a 30-day window
+3 evidence quotes and 2 startup ideas per pain point found


### PR DESCRIPTION
Adds IdeaFast: a Reddit pain point finder for founders. It scans a subreddit, scores the recurring complaints, shows the quotes behind each one, and turns them into startup ideas.

New file: `src/content/tools/ideafast.md`, following the template in the README.

Free offer:
- 1 free Reddit pain point scan
- Scan covers 1 subreddit over a 30-day window
- 3 evidence quotes and 2 startup ideas per pain point found

Tags are all existing ones on the site: research, user-research, AI, saas. Thumbnail is a 180x180 PNG.

Thanks for maintaining the list.