### PR TITLE
Add MetadataRemover.ai

### DIFF
--- a/src/content/tools/metadataremover-ai.md
+++ b/src/content/tools/metadataremover-ai.md
@@ -1,0 +1,9 @@
+---
+title: "MetadataRemover.ai"
+link: "https://metadataremover.ai/"
+thumbnail: "https://metadataremover.ai/apple-icon.png?cb30167cd4eea129"
+snippet: "Free online metadata remover — strip EXIF, GPS, XMP, IPTC and AI data from JPG, PNG and WebP images locally in your browser. 100% private, fast, no sign-up."
+tags: ["security","privacy","productivity"]
+createdAt: 2026-08-20T15:47:11.500Z
+---
+Free browser-local metadata removal for supported images, PDFs, DOCX files, videos, and MP3 audio. No account is required.


### PR DESCRIPTION
Adds MetadataRemover.ai, a free browser-local tool for removing supported metadata from images, PDFs, DOCX files, videos, and MP3 audio. No account is required.