### PR TITLE
Add Image2Base64

### DIFF
--- a/src/content/tools/image2base64.md
+++ b/src/content/tools/image2base64.md
@@ -1,0 +1,14 @@
+---
+title: Image2Base64
+link: https://image2base64.com
+thumbnail: https://image2base64.com/icon-192.png
+snippet: >-
+  Convert PNG, JPG, SVG, WebP, and GIF images to Base64 data URIs in the
+  browser, then copy raw Base64, data URI, HTML, or CSS snippets.
+tags: ["converter-online", "encoder", "decoder", "devtools"]
+createdAt: 2026-08-21T00:00:00.000Z
+---
+Image to Base64 and Base64 to image, both directions
+PNG, JPG, SVG, WebP, and GIF
+Runs in the browser with FileReader; no upload or sign-up
+Copy-ready data URI, HTML img, and CSS snippets


### PR DESCRIPTION
Adds Image2Base64 to the free developer tools list.

**Tool:** Image2Base64
**URL:** https://image2base64.com

Free in-browser PNG/JPG/SVG/WebP/GIF converter that outputs Base64, data URIs, and HTML/CSS snippets. No upload, no account.

Tags follow existing entries (`converter-online`, `encoder`, `decoder`, `devtools`). Thumbnail is the 192px site icon.

Disclosure: I maintain the site.


Made with [Cursor](https://cursor.com)