### PR TITLE
Add Whoops SEO Labs

### DIFF
--- a/src/content/tools/whoops-seo-labs.md
+++ b/src/content/tools/whoops-seo-labs.md
@@ -1,0 +1,14 @@
+---
+title: Whoops SEO Labs
+link: https://seo.whoops.com.tw
+thumbnail: https://seo.whoops.com.tw/wp-content/uploads/2026/06/whoops-seo-favicon-512.png
+snippet: >-
+  Free no-sign-in tools for reviewing webpage SEO signals and preparing
+  structured files for AI visibility workflows.
+tags: ["AI", "SEO", "analytics", "web-development"]
+createdAt: 2026-08-21T00:00:00.000Z
+---
+Review public webpages and HTML SEO signals
+Generate llms.txt files
+Create OKF structured knowledge
+Use every tool without an account


### PR DESCRIPTION
Adds Whoops SEO Labs, a free no-sign-in toolkit for webpage SEO checks and AI visibility workflows.

The entry includes:
- the canonical product URL
- a public 512px product thumbnail
- existing directory tags
- a concise list of free features

Validation:
- parsed the new frontmatter with `gray-matter` and checked all required fields
- verified the thumbnail returns HTTP 200 with `image/png`
- attempted the repository build; it is currently blocked by a pre-existing YAML parse error in `src/content/tools/poof.md`