### PR TITLE
Add iq.pfa87.cc — free online IQ screening

### DIFF
--- a/src/content/tools/free-online-iq-screening-iq-pfa87-cc.md
+++ b/src/content/tools/free-online-iq-screening-iq-pfa87-cc.md
@@ -1,0 +1,9 @@
+---
+title: "iq.pfa87.cc — Free online IQ screening"
+link: "https://iq.pfa87.cc/"
+thumbnail: "https://iq.pfa87.cc/favicon.svg"
+snippet: "Free online IQ screening across six domains (verbal, numerical, matrix, spatial, working memory, processing speed). No signup, no payment. Results stay in the browser. Indicative, not a clinical exam."
+tags: ["learning-resource", "skill-test"]
+createdAt: 2026-09-04T09:31:52Z
+---
+Free online IQ screening (~45–50 minutes). Six domains. No signup; results stay in the browser. Indicative only — not a psychologist exam.


### PR DESCRIPTION
## Summary
Adds [iq.pfa87.cc](https://iq.pfa87.cc/) to freestuff.dev.

- Free online IQ screening (~45–50 min), six cognitive domains
- No signup / no payment; results stay in the browser
- Tagged `learning-resource`, `skill-test`
- Clearly framed as indicative, not a clinical exam

Submitted via freestuff.dev/submit flow.