### PR TITLE
Add TriageBox — free Chrome extension for Gmail triage

### DIFF
--- a/src/content/tools/triagebox.md
+++ b/src/content/tools/triagebox.md
@@ -1,0 +1,14 @@
+---
+title: "TriageBox"
+link: "https://triagebox.pfa87.cc/"
+thumbnail: "https://triagebox.pfa87.cc/logo-120.png"
+snippet: "Free Chrome extension to clear Gmail clutter — archive, snooze, and unsubscribe from a popup, then sweep a sender with an exact count first. AI optional on your own key; data stays in your browser."
+tags: ["productivity", "mail"]
+createdAt: 2026-09-04T09:34:31.000Z
+---
+Free to install on the Chrome Web Store
+No TriageBox account or subscription
+Archive, snooze, label, unsubscribe, and sender sweeps from a Chrome popup
+Exact count shown before any bulk action
+No developer-operated backend — Gmail data stays in your browser
+Optional AI summaries only if you add your own Gemini or xAI key


### PR DESCRIPTION
## Add TriageBox

[TriageBox](https://triagebox.pfa87.cc/) is a free Chrome extension for clearing Gmail clutter: archive, snooze, unsubscribe, and sender sweeps from a popup/side panel — with an exact count before anything moves.

### Why it fits freestuff.dev
- **Truly free** — free on the Chrome Web Store, no TriageBox account, no subscription
- **Privacy-friendly** — no developer-operated backend; processing runs in the user's browser
- **Useful for developers** — inbox triage / productivity (similar free productivity listings)

Live listing: https://chromewebstore.google.com/detail/triagebox-ai-checker-for/fdkbolcjccjkgadblcfnbnlibaiaellj

Thank you for maintaining freestuff.dev!