### PR TITLE
Add Agentic Ideas — free HN-style idea board (EN/FR/ES)

### DIFF
--- a/src/content/tools/agentic-ideas.md
+++ b/src/content/tools/agentic-ideas.md
@@ -1,0 +1,12 @@
+---
+title: "Agentic Ideas"
+link: "https://ideas.pfa87.cc/"
+thumbnail: "https://ideas.pfa87.cc/favicon.svg"
+snippet: "HN-style idea board for things to do with AI agents. Post, vote, and comment in English, français, or español."
+tags: ["AI", "community"]
+createdAt: 2026-09-04T09:30:00.000Z
+---
+Free to browse, post, vote, and comment
+Multilingual board (EN / FR / ES)
+Hot, Top, and New sorting
+No ads


### PR DESCRIPTION
Adds Agentic Ideas (https://ideas.pfa87.cc/) — a free HN-style idea board (EN/FR/ES). No signup wall; upvote and share product/indie ideas.