### PR TITLE
Add six free GuGuData developer tools

### DIFF
--- a/src/content/tools/contextstacker.md
+++ b/src/content/tools/contextstacker.md
@@ -1,0 +1,11 @@
+---
+title: ContextStacker
+link: https://contextstacker.com/
+thumbnail: https://contextstacker.com/og.png
+snippet: Ask across workspace documents and approved APIs while keeping every supporting source visible.
+tags: ["AI", "productivity", "developer-tools"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Free plan for document workspaces
+PDF, DOCX, Markdown, TXT, and CSV imports
+Sourced answers with visible supporting evidence

--- a/src/content/tools/foxifill.md
+++ b/src/content/tools/foxifill.md
@@ -1,0 +1,11 @@
+---
+title: FoxiFill
+link: https://foxifill.com/
+thumbnail: https://foxifill.com/og.jpg
+snippet: A free local-first Chrome extension for reviewable, AI-assisted form filling.
+tags: ["AI", "browser-extension", "productivity"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Free Chrome extension
+Local-first form context capture
+Review suggestions before applying values

--- a/src/content/tools/gugudata.md
+++ b/src/content/tools/gugudata.md
@@ -1,0 +1,11 @@
+---
+title: GuGuData
+link: https://gugudata.io/
+thumbnail: https://gugudata.io/og-image.png
+snippet: Production-oriented REST APIs for document conversion, data extraction, computer vision, and structured datasets.
+tags: ["API", "developer-tools", "data"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Free tier for evaluating individual API endpoints
+Interactive API examples
+Document, image, and structured-data APIs

--- a/src/content/tools/handy.md
+++ b/src/content/tools/handy.md
@@ -1,0 +1,11 @@
+---
+title: Handy
+link: https://tools.parryqiu.com/en
+thumbnail: https://tools.parryqiu.com/brand/handy-logo.png
+snippet: Browser-based utilities for text, web data, images, PDFs, QR codes, and developer workflows.
+tags: ["developer-tools", "productivity", "web-tools"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Thirty-two browser-based utilities
+Text, image, PDF, QR code, and web-data tools
+No software installation required

--- a/src/content/tools/highlightcode.md
+++ b/src/content/tools/highlightcode.md
@@ -1,0 +1,11 @@
+---
+title: HighlightCode
+link: https://highlightcode.com/
+thumbnail: https://highlightcode.com/assets/images/logo.png
+snippet: Highlight source code online and copy formatted snippets into documents and technical writing.
+tags: ["developer-tools", "text-editor", "productivity"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Online syntax highlighting
+Copy formatted code into Word, OneNote, and Google Docs
+No software installation required

--- a/src/content/tools/promplify.md
+++ b/src/content/tools/promplify.md
@@ -1,0 +1,11 @@
+---
+title: Promplify
+link: https://promplify.com/
+thumbnail: https://promplify.com/web-app-manifest-512x512.png
+snippet: Open-source prompt management for creating, versioning, sharing, and reusing AI workflows.
+tags: ["AI", "developer-tools", "opensource"]
+createdAt: 2026-09-05T13:29:11+08:00
+---
+Open-source and self-hostable
+Prompt version history and reusable templates
+Categories, tags, sharing, and API access


### PR DESCRIPTION
## Summary

- add GuGuData and ContextStacker
- add FoxiFill and HighlightCode
- add Promplify and Handy

Each entry links to the canonical product page and describes its verified free offering.

## Validation

- `git diff --check` passes
- `yarn build` is currently blocked by a pre-existing YAML parse error in `src/content/tools/poof.md`