### PR TITLE
Add Real Job Work From Home to remote job listings

### DIFF
--- a/src/content/tools/real-job-work-from-home.md
+++ b/src/content/tools/real-job-work-from-home.md
@@ -1,0 +1,11 @@
+---
+title: "Real Job Work From Home"
+link: "https://realjobworkfromhome.com/"
+thumbnail: "https://realjobworkfromhome.com/social-share.png"
+snippet: "Curated remote jobs open to worldwide applicants."
+tags: ["job-listing", "remote"]
+createdAt: 2026-09-06T00:00:00+00:00
+---
+Browse worldwide remote job listings for free without creating an account.
+Search by job title, company, or skill and filter by category, job type, and salary availability.
+Explore company profiles and apply directly on employer websites.


### PR DESCRIPTION
Adds Real Job Work From Home, a free curated job board for worldwide remote opportunities. Users can browse and search listings, filter roles, explore company profiles, and apply on employer websites without creating an account.

The entry follows the README metadata template and lists the free features. The website submission form returned an error, so this uses the documented GitHub contribution route.